### PR TITLE
Adds custom resource-types file for ckanext-resource-type-validation

### DIFF
--- a/ckanext/cuprit/config/resource_types.json
+++ b/ckanext/cuprit/config/resource_types.json
@@ -1,0 +1,65 @@
+{
+  "allowed_extensions": [
+      "csv", "xls", "odt", "rdf", "txt", "jpeg", "png", "tiff", "pdf"
+  ],
+  "allowed_overrides": {
+      "application/octet-stream": ["*"],
+      "text/plain": [
+          "application/sparql-query",
+          "application/x-ascii-grid",
+          "application/xml",
+          "application/json",
+          "application/rdf+xml",
+          "application/vnd.google-earth.kml+xml",
+          "model/mtl",
+          "text/*"
+      ],
+      "application/xml": [
+          "application/rdf+xml",
+          "application/vnd.google-earth.kml+xml"
+      ],
+      "application/zip": [
+          "application/vnd.google-earth.kmz",
+          "application/x-filegdb"
+      ],
+      "application/CDFV2": [
+          "application/vnd.ms-excel",
+          "application/msword",
+          "application/vnd.ms-powerpoint"
+      ]
+  },
+  "equal_types": [
+      ["text/rtf", "text/richtext", "application/rtf", "application/x-rtf"],
+      ["text/xml", "application/xml"],
+      ["application/x-cdf", "application/x-netcdf"],
+      ["application/msaccess", "application/x-msaccess", "application/vnd.msaccess", "application/vnd.ms-access", "application/mdb", "application/x-mdb"],
+      ["application/CDFV2", "application/CDFV2-unknown"]
+  ],
+  "generic_types": ["application/octet-stream", "text/plain"],
+  "archive_types": ["application/zip", "application/x-tar"],
+  "extra_mimetypes": {
+      ".accdb": "application/msaccess",
+      ".asc": "application/x-ascii-grid",
+      ".ecw": "application/octet-stream",
+      ".esri": "x-gis/x-shapefile",
+      ".fgdb": "application/x-filegdb",
+      ".gdb": "application/x-filegdb",
+      ".geojson": "application/json",
+      ".geotiff": "image/tiff",
+      ".gpkg": "application/x-sqlite3",
+      ".gpx": "application/xml",
+      ".kml": "application/vnd.google-earth.kml+xml",
+      ".kmz": "application/vnd.google-earth.kmz",
+      ".mtl": "model/mtl",
+      ".obj": "text/plain",
+      ".n3": "text/n3",
+      ".rdf": "application/rdf+xml",
+      ".shp": "x-gis/x-shapefile",
+      ".sparql": "application/sparql-query",
+      ".tab": "text/plain",
+      ".topojson": "application/json",
+      ".ttf": "text/plain",
+      ".wfs": "application/xml",
+      ".wmts": "application/xml"
+  }
+}


### PR DESCRIPTION
Adds custom resource-types file for [ckanext-resource-type-validation](https://github.com/qld-gov-au/ckanext-resource-type-validation).

- install extension
- add it to ```ckan.plugins = resource_type_validation```
- set env var ```CKANEXT__RESOURCE_VALIDATION__TYPES_FILE=/srv/app/src/ckanext-cuprit/ckanext/cuprit/config/resource_types.json ```